### PR TITLE
Corrected typo in Basic concepts section

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ handler.
 In order to push events into reactor, you can use `notify`:
 
 ```clj
-(mr/notify r "key" {:my "payload"})
+(mr/notify reactor "key" {:my "payload"})
 ```
 
 ### Selectors


### PR DESCRIPTION
If I am not mistake "r" should be "reactor" in:

```
(mr/notify r "key" {:my "payload"})
```
