### PR TITLE
Make deftest names unique, import needed Java classes

### DIFF
--- a/src/clojure/clojurewerkz/meltdown/consumers.clj
+++ b/src/clojure/clojurewerkz/meltdown/consumers.clj
@@ -36,10 +36,6 @@
   [^Registration reg]
   (.isPaused reg))
 
-(defn ^boolean paused?
-  [^Registration reg]
-  (.isPaused reg))
-
 (defn ^Registration pause
   [^Registration reg]
   (.pause reg))

--- a/test/clojurewerkz/meltdown/stream_graph_test.clj
+++ b/test/clojurewerkz/meltdown/stream_graph_test.clj
@@ -57,7 +57,7 @@
       (is (= 6 d)))))
 
 
-(deftest basic-stream-map-filter-reduce-test
+(deftest basic-stream-map-filter-reduce-test-2
   (let [res1 (atom nil)
         res2 (atom nil)
         summarizer #(+ %1 %2)

--- a/test/clojurewerkz/meltdown/throughput_test.clj
+++ b/test/clojurewerkz/meltdown/throughput_test.clj
@@ -6,6 +6,8 @@
             [clojurewerkz.meltdown.events    :as me])
   (:import [java.util.concurrent CountDownLatch TimeUnit]
            [reactor.event.dispatch RingBufferDispatcher]
+           [reactor.event Event]
+           [reactor.core Reactor]
            [com.lmax.disruptor.dsl ProducerType]
            [com.lmax.disruptor YieldingWaitStrategy]))
 


### PR DESCRIPTION
Also eliminate a redundant definition of the function paused?

Found using a pre-release version of the Eastwood Clojure lint tool.
