### PR TITLE
Corrections for a few minor issues found via Eastwood lint tool

### DIFF
--- a/src/clojure/clojurewerkz/meltdown/consumers.clj
+++ b/src/clojure/clojurewerkz/meltdown/consumers.clj
@@ -34,7 +34,7 @@
   [^IFn f]
   (IFnConsumer. f))
 
-(defn ^boolean paused?
+(defn ^{:tag 'boolean} paused?
   [^Registration reg]
   (.isPaused reg))
 
@@ -47,7 +47,7 @@
   (.resume reg))
 
 
-(defn ^boolean cancelled?
+(defn ^{:tag 'boolean} cancelled?
   [^Registration reg]
   (.isCancelled reg))
 
@@ -55,7 +55,7 @@
   [^Registration reg]
   (.cancel reg))
 
-(defn ^boolean cancel-after-use?
+(defn ^{:tag 'boolean} cancel-after-use?
   [^Registration reg]
   (.isCancelAfterUse reg))
 
@@ -72,7 +72,7 @@
   (let [^Registry xs (consumer-registry-of r)]
     (remove nil? (into [] xs))))
 
-(defn ^long consumer-count
+(defn ^{:tag 'long} consumer-count
   [^Reactor r]
   (let [^Registry xs (consumer-registry-of r)]
     (count (remove nil? (into [] xs)))))

--- a/src/clojure/clojurewerkz/meltdown/reactor.clj
+++ b/src/clojure/clojurewerkz/meltdown/reactor.clj
@@ -34,6 +34,7 @@
            [reactor.event Event]
            java.lang.Throwable
            [reactor.core Reactor]
+           [reactor.core.composable.spec DeferredStreamSpec]
            [reactor.core.spec Reactors]))
 
 (def dispatcher-types
@@ -70,7 +71,7 @@
   ([^Reactor reactor payload]
      (.notify reactor (Event. payload)))
   ([^Reactor reactor key payload]
-     (.notify reactor ^Object key ^Event (Event. payload) nil))
+     (.notify reactor ^Object key (Event. payload) nil))
   ([^Reactor reactor key payload ^IFn completion-fn]
      (.notify reactor ^Object key (Event. payload) ^Consumer (mc/from-fn completion-fn))))
 


### PR DESCRIPTION
Type tags like ^boolean on Vars are ignored by the Clojure compiler.
To have any effect, they should be of the form ^{:tag 'boolean}.

Type tags on Java constructor expressions like ^Event (Event. payload)
are ignored by the Clojure compiler, and I think the type is
automatically inferred by the Clojure compiler anyway.

Added an import of a Java class that was used as a type tag.
